### PR TITLE
Adjust cast row aspect ratio

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -307,8 +307,8 @@ private fun CastRow(
 				onClick = {
 					onItemClick(item)
 				},
-				width = 160.dp * 2 / 3,
-				aspectRatio = 2f / 3f,
+                                width = (160.dp * (2f / 3f)), // Explicitly: rowHeight * aspectRatio
+                                aspectRatio = 2f / 3f,
 				showTitle = false,
 			)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -289,8 +289,8 @@ private fun HorizontalCardRow(
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun CastRow(
-                                // Ensure cards stay within the 160.dp row height
-                                width = 160.dp * 2f / 3f,
+	// Ensure cards stay within the 160.dp row height
+	width = 160.dp * 2f / 3f,
 	onItemClick: (org.jellyfin.sdk.model.api.BaseItemDto) -> Unit,
 	getItemImageUrl: (org.jellyfin.sdk.model.api.BaseItemDto) -> String?,
 	modifier: Modifier = Modifier,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -307,8 +307,8 @@ private fun CastRow(
 				onClick = {
 					onItemClick(item)
 				},
-                                width = (160.dp * (2f / 3f)), // Explicitly: rowHeight * aspectRatio
-                                aspectRatio = 2f / 3f,
+				width = (160.dp * (2f / 3f)), // Explicitly: rowHeight * aspectRatio
+				aspectRatio = 2f / 3f,
 				showTitle = false,
 			)
 		}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -289,7 +289,8 @@ private fun HorizontalCardRow(
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun CastRow(
-	items: List<org.jellyfin.sdk.model.api.BaseItemDto>,
+                                // Ensure cards stay within the 160.dp row height
+                                width = 160.dp * 2f / 3f,
 	onItemClick: (org.jellyfin.sdk.model.api.BaseItemDto) -> Unit,
 	getItemImageUrl: (org.jellyfin.sdk.model.api.BaseItemDto) -> String?,
 	modifier: Modifier = Modifier,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -289,29 +289,29 @@ private fun HorizontalCardRow(
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun CastRow(
-        items: List<org.jellyfin.sdk.model.api.BaseItemDto>,
-        onItemClick: (org.jellyfin.sdk.model.api.BaseItemDto) -> Unit,
-        getItemImageUrl: (org.jellyfin.sdk.model.api.BaseItemDto) -> String?,
-        modifier: Modifier = Modifier,
+	items: List<org.jellyfin.sdk.model.api.BaseItemDto>,
+	onItemClick: (org.jellyfin.sdk.model.api.BaseItemDto) -> Unit,
+	getItemImageUrl: (org.jellyfin.sdk.model.api.BaseItemDto) -> String?,
+	modifier: Modifier = Modifier,
 ) {
 	LazyRow(
 		horizontalArrangement = Arrangement.spacedBy(16.dp),
 		modifier = modifier.height(160.dp),
 		contentPadding = PaddingValues(horizontal = 48.dp),
 	) {
-                items(items) { item ->
-                        MediaCard(
-                                item = item,
-                                imageUrl = getItemImageUrl(item),
-                                onClick = {
-                                        onItemClick(item)
-                                },
-                                width = 160.dp * 2 / 3,
-                                aspectRatio = 2f / 3f,
-                                showTitle = false,
-                        )
-                }
-        }
+		items(items) { item ->
+			MediaCard(
+				item = item,
+				imageUrl = getItemImageUrl(item),
+				onClick = {
+					onItemClick(item)
+				},
+				width = 160.dp * 2 / 3,
+				aspectRatio = 2f / 3f,
+				showTitle = false,
+			)
+		}
+	}
 }
 
 /**
@@ -414,11 +414,11 @@ private fun SeriesDetailImmersiveList(
 							)
 						}
 						ImmersiveListLayout.VERTICAL_GRID -> {
-                                                        CastRow(
-                                                                items = section.items,
-                                                                onItemClick = onItemClick,
-                                                                getItemImageUrl = getItemImageUrl,
-                                                        )
+							CastRow(
+								items = section.items,
+								onItemClick = onItemClick,
+								getItemImageUrl = getItemImageUrl,
+							)
 						}
 					}
 				}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -284,34 +284,34 @@ private fun HorizontalCardRow(
 }
 
 /**
- * Horizontal row of cards for cast (single row)
+ * Horizontal row of cast cards (single row)
  */
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun VerticalGrid(
-	items: List<org.jellyfin.sdk.model.api.BaseItemDto>,
-	onItemClick: (org.jellyfin.sdk.model.api.BaseItemDto) -> Unit,
-	getItemImageUrl: (org.jellyfin.sdk.model.api.BaseItemDto) -> String?,
-	modifier: Modifier = Modifier,
+private fun CastRow(
+        items: List<org.jellyfin.sdk.model.api.BaseItemDto>,
+        onItemClick: (org.jellyfin.sdk.model.api.BaseItemDto) -> Unit,
+        getItemImageUrl: (org.jellyfin.sdk.model.api.BaseItemDto) -> String?,
+        modifier: Modifier = Modifier,
 ) {
 	LazyRow(
 		horizontalArrangement = Arrangement.spacedBy(16.dp),
 		modifier = modifier.height(160.dp),
 		contentPadding = PaddingValues(horizontal = 48.dp),
 	) {
-		items(items) { item ->
-			MediaCard(
-				item = item,
-				imageUrl = getItemImageUrl(item),
-				onClick = {
-					onItemClick(item)
-				},
-				width = 120.dp,
-				aspectRatio = 1f, // Square aspect ratio for cast photos
-				showTitle = false,
-			)
-		}
-	}
+                items(items) { item ->
+                        MediaCard(
+                                item = item,
+                                imageUrl = getItemImageUrl(item),
+                                onClick = {
+                                        onItemClick(item)
+                                },
+                                width = 160.dp * 2 / 3,
+                                aspectRatio = 2f / 3f,
+                                showTitle = false,
+                        )
+                }
+        }
 }
 
 /**
@@ -414,11 +414,11 @@ private fun SeriesDetailImmersiveList(
 							)
 						}
 						ImmersiveListLayout.VERTICAL_GRID -> {
-							VerticalGrid(
-								items = section.items,
-								onItemClick = onItemClick,
-								getItemImageUrl = getItemImageUrl,
-							)
+                                                        CastRow(
+                                                                items = section.items,
+                                                                onItemClick = onItemClick,
+                                                                getItemImageUrl = getItemImageUrl,
+                                                        )
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
- rename `VerticalGrid` composable to `CastRow`
- use poster aspect ratio for cast cards
- size cast cards so they fit inside the 160 dp row

## Testing
- `./gradlew testDebugUnitTest` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6854f79adf448327ad431a4489e39ddf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated cast cards in series detail view to display as vertical rectangles instead of squares for improved visual consistency.
  - Changed cast display from a vertical grid to a horizontal scrollable row for easier browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->