### PR TITLE
Use string resources in Compose screens

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeasonScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeasonScreen.kt
@@ -20,12 +20,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.jellyfin.androidtv.ui.composable.tv.ImmersiveList
@@ -88,11 +88,11 @@ private fun LoadingState(
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
 			CircularProgressIndicator()
-                        Text(
-                                text = stringResource(R.string.compose_loading_seasons),
-                                style = MaterialTheme.typography.bodyLarge,
-                                modifier = Modifier.padding(top = 16.dp),
-                        )
+			Text(
+				text = stringResource(R.string.compose_loading_seasons),
+				style = MaterialTheme.typography.bodyLarge,
+				modifier = Modifier.padding(top = 16.dp),
+			)
 		}
 	}
 }
@@ -106,11 +106,11 @@ private fun ErrorState(
 		modifier = modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-                Text(
-                        text = stringResource(R.string.compose_error, error),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.error,
-                )
+		Text(
+			text = stringResource(R.string.compose_error, error),
+			style = MaterialTheme.typography.bodyLarge,
+			color = MaterialTheme.colorScheme.error,
+		)
 	}
 }
 
@@ -122,10 +122,10 @@ private fun EmptyState(
 		modifier = modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-                Text(
-                        text = stringResource(R.string.compose_no_seasons),
-                        style = MaterialTheme.typography.bodyLarge,
-                )
+		Text(
+			text = stringResource(R.string.compose_no_seasons),
+			style = MaterialTheme.typography.bodyLarge,
+		)
 	}
 }
 
@@ -252,24 +252,24 @@ private fun SeasonHeaderOverlay(
 				horizontalArrangement = Arrangement.spacedBy(16.dp),
 				verticalAlignment = Alignment.CenterVertically,
 			) {
-                                Text(
-                                        text = pluralStringResource(
-                                                R.plurals.episodes,
-                                                episodeCount,
-                                                episodeCount,
-                                        ),
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        color = Color.White.copy(alpha = 0.8f),
-                                )
+				Text(
+					text = pluralStringResource(
+						R.plurals.episodes,
+						episodeCount,
+						episodeCount,
+					),
+					style = MaterialTheme.typography.bodyLarge,
+					color = Color.White.copy(alpha = 0.8f),
+				)
 				
 				// Show season info if available
 				uiState.season?.let { season ->
 					season.productionYear?.let { year ->
-                                                Text(
-                                                        text = stringResource(R.string.dot_separator),
-                                                        style = MaterialTheme.typography.bodyLarge,
-                                                        color = Color.White.copy(alpha = 0.6f),
-                                                )
+						Text(
+							text = stringResource(R.string.dot_separator),
+							style = MaterialTheme.typography.bodyLarge,
+							color = Color.White.copy(alpha = 0.6f),
+						)
 						Text(
 							text = year.toString(),
 							style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeasonScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeasonScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -86,11 +88,11 @@ private fun LoadingState(
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
 			CircularProgressIndicator()
-			Text(
-				text = "Loading seasons...",
-				style = MaterialTheme.typography.bodyLarge,
-				modifier = Modifier.padding(top = 16.dp),
-			)
+                        Text(
+                                text = stringResource(R.string.compose_loading_seasons),
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(top = 16.dp),
+                        )
 		}
 	}
 }
@@ -104,11 +106,11 @@ private fun ErrorState(
 		modifier = modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-		Text(
-			text = "Error: $error",
-			style = MaterialTheme.typography.bodyLarge,
-			color = MaterialTheme.colorScheme.error,
-		)
+                Text(
+                        text = stringResource(R.string.compose_error, error),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.error,
+                )
 	}
 }
 
@@ -120,10 +122,10 @@ private fun EmptyState(
 		modifier = modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-		Text(
-			text = "No seasons found",
-			style = MaterialTheme.typography.bodyLarge,
-		)
+                Text(
+                        text = stringResource(R.string.compose_no_seasons),
+                        style = MaterialTheme.typography.bodyLarge,
+                )
 	}
 }
 
@@ -250,20 +252,24 @@ private fun SeasonHeaderOverlay(
 				horizontalArrangement = Arrangement.spacedBy(16.dp),
 				verticalAlignment = Alignment.CenterVertically,
 			) {
-				Text(
-					text = "$episodeCount episodes",
-					style = MaterialTheme.typography.bodyLarge,
-					color = Color.White.copy(alpha = 0.8f),
-				)
+                                Text(
+                                        text = pluralStringResource(
+                                                R.plurals.episodes,
+                                                episodeCount,
+                                                episodeCount,
+                                        ),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = Color.White.copy(alpha = 0.8f),
+                                )
 				
 				// Show season info if available
 				uiState.season?.let { season ->
 					season.productionYear?.let { year ->
-						Text(
-							text = "•",
-							style = MaterialTheme.typography.bodyLarge,
-							color = Color.White.copy(alpha = 0.6f),
-						)
+                                                Text(
+                                                        text = stringResource(R.string.dot_separator),
+                                                        style = MaterialTheme.typography.bodyLarge,
+                                                        color = Color.White.copy(alpha = 0.6f),
+                                                )
 						Text(
 							text = year.toString(),
 							style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -470,7 +470,7 @@ private fun SeriesInformationOverlay(
 	focusedItem: BaseItemDto?,
 	getItemLogoUrl: (BaseItemDto) -> String? = { null },
 	modifier: Modifier = Modifier,
-) {
+                                                        startYear != null && series.status?.lowercase() == "continuing" -> "$startYear - Present"
 	// Show series info when no item is focused, otherwise show focused item info
 	val displayItem = focusedItem ?: series
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -107,11 +109,11 @@ private fun LoadingState(
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
 			CircularProgressIndicator()
-			Text(
-				text = "Loading seasons...",
-				style = MaterialTheme.typography.bodyLarge,
-				modifier = Modifier.padding(top = 16.dp),
-			)
+                        Text(
+                                text = stringResource(R.string.compose_loading_seasons),
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(top = 16.dp),
+                        )
 		}
 	}
 }
@@ -125,11 +127,11 @@ private fun ErrorState(
 		modifier = modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-		Text(
-			text = "Error: $error",
-			style = MaterialTheme.typography.bodyLarge,
-			color = MaterialTheme.colorScheme.error,
-		)
+                Text(
+                        text = stringResource(R.string.compose_error, error),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.error,
+                )
 	}
 }
 
@@ -141,10 +143,10 @@ private fun EmptyState(
 		modifier = modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-		Text(
-			text = "No seasons found",
-			style = MaterialTheme.typography.bodyLarge,
-		)
+                Text(
+                        text = stringResource(R.string.compose_no_seasons),
+                        style = MaterialTheme.typography.bodyLarge,
+                )
 	}
 }
 
@@ -198,12 +200,12 @@ private fun FocusedItemOverlay(
 		) {
 			item?.let { focusedItem ->
 				// Title
-				Text(
-					text = focusedItem.name ?: "Unknown",
-					style = MaterialTheme.typography.displayMedium.copy(
-						fontWeight = FontWeight.Bold,
-						fontSize = 42.sp,
-					),
+                                Text(
+                                        text = focusedItem.name ?: stringResource(R.string.lbl_bracket_unknown),
+                                        style = MaterialTheme.typography.displayMedium.copy(
+                                                fontWeight = FontWeight.Bold,
+                                                fontSize = 42.sp,
+                                        ),
 					color = Color.White,
 					maxLines = 2,
 					overflow = TextOverflow.Ellipsis,
@@ -229,11 +231,15 @@ private fun FocusedItemOverlay(
 					focusedItem.runTimeTicks?.let { ticks ->
 						val minutes = (ticks / 10_000_000) / 60
 						if (minutes > 0) {
-							Text(
-								text = "${minutes}m",
-								style = MaterialTheme.typography.titleLarge,
-								color = Color.White.copy(alpha = 0.7f),
-							)
+                                                        Text(
+                                                                text = pluralStringResource(
+                                                                        R.plurals.minutes,
+                                                                        minutes,
+                                                                        minutes,
+                                                                ),
+                                                                style = MaterialTheme.typography.titleLarge,
+                                                                color = Color.White.copy(alpha = 0.7f),
+                                                        )
 						}
 					}
 				}
@@ -463,12 +469,12 @@ private fun SeriesInformationOverlay(
 		) {
 			// Title
 			displayItem?.let { item ->
-				Text(
-					text = item.name ?: "Unknown Title",
-					style = MaterialTheme.typography.displayMedium.copy(
-						fontWeight = FontWeight.Bold,
-						fontSize = 48.sp,
-					),
+                                Text(
+                                        text = item.name ?: stringResource(R.string.compose_unknown_title),
+                                        style = MaterialTheme.typography.displayMedium.copy(
+                                                fontWeight = FontWeight.Bold,
+                                                fontSize = 48.sp,
+                                        ),
 					color = Color.White,
 					maxLines = 2,
 					overflow = TextOverflow.Ellipsis,
@@ -487,12 +493,12 @@ private fun SeriesInformationOverlay(
 						// Show series year range
 						val startYear = series.productionYear
 						val endYear = series.endDate?.year
-						val yearText = when {
-							startYear != null && endYear != null && endYear != startYear -> "$startYear - $endYear"
-							startYear != null && series.status?.lowercase() == "continuing" -> "$startYear - Present"
-							startYear != null -> startYear.toString()
-							else -> null
-						}
+                                                val yearText = when {
+                                                        startYear != null && endYear != null && endYear != startYear -> "$startYear - $endYear"
+                                                        startYear != null && series.status?.lowercase() == "continuing" -> "$startYear - ${stringResource(R.string.lbl_present)}"
+                                                        startYear != null -> startYear.toString()
+                                                        else -> null
+                                                }
 						yearText?.let { year ->
 							Text(
 								text = year,
@@ -517,12 +523,12 @@ private fun SeriesInformationOverlay(
 							verticalAlignment = Alignment.CenterVertically,
 							horizontalArrangement = Arrangement.spacedBy(4.dp),
 						) {
-							Icon(
-								painter = painterResource(R.drawable.ic_star),
-								contentDescription = "Rating",
-								tint = Color.Yellow,
-								modifier = Modifier.size(20.dp),
-							)
+                                                        Icon(
+                                                                painter = painterResource(R.drawable.ic_star),
+                                                                contentDescription = stringResource(R.string.lbl_rating),
+                                                                tint = Color.Yellow,
+                                                                modifier = Modifier.size(20.dp),
+                                                        )
 							Text(
 								text = String.format("%.1f", rating),
 								style = MaterialTheme.typography.titleLarge.copy(
@@ -562,11 +568,15 @@ private fun SeriesInformationOverlay(
 					if (focusedItem == null) {
 						series?.childCount?.let { count ->
 							if (count > 0) {
-								Text(
-									text = "$count Episodes",
-									style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
-									color = Color.White.copy(alpha = 0.7f),
-								)
+                                                                Text(
+                                                                        text = pluralStringResource(
+                                                                                R.plurals.episodes,
+                                                                                count,
+                                                                                count,
+                                                                        ),
+                                                                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
+                                                                        color = Color.White.copy(alpha = 0.7f),
+                                                                )
 							}
 						}
 					}
@@ -576,11 +586,15 @@ private fun SeriesInformationOverlay(
 						item.runTimeTicks?.let { ticks ->
 							val minutes = (ticks / 10_000_000) / 60
 							if (minutes > 0) {
-								Text(
-									text = "${minutes}m",
-									style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
-									color = Color.White.copy(alpha = 0.7f),
-								)
+                                                                Text(
+                                                                        text = pluralStringResource(
+                                                                                R.plurals.minutes,
+                                                                                minutes,
+                                                                                minutes,
+                                                                        ),
+                                                                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
+                                                                        color = Color.White.copy(alpha = 0.7f),
+                                                                )
 							}
 						}
 					}

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/compose/ComposeSeriesScreen.kt
@@ -109,11 +109,11 @@ private fun LoadingState(
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
 			CircularProgressIndicator()
-                        Text(
-                                text = stringResource(R.string.compose_loading_seasons),
-                                style = MaterialTheme.typography.bodyLarge,
-                                modifier = Modifier.padding(top = 16.dp),
-                        )
+			Text(
+				text = stringResource(R.string.compose_loading_seasons),
+				style = MaterialTheme.typography.bodyLarge,
+				modifier = Modifier.padding(top = 16.dp),
+			)
 		}
 	}
 }
@@ -127,11 +127,11 @@ private fun ErrorState(
 		modifier = modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-                Text(
-                        text = stringResource(R.string.compose_error, error),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.error,
-                )
+		Text(
+			text = stringResource(R.string.compose_error, error),
+			style = MaterialTheme.typography.bodyLarge,
+			color = MaterialTheme.colorScheme.error,
+		)
 	}
 }
 
@@ -143,10 +143,10 @@ private fun EmptyState(
 		modifier = modifier.fillMaxSize(),
 		contentAlignment = Alignment.Center,
 	) {
-                Text(
-                        text = stringResource(R.string.compose_no_seasons),
-                        style = MaterialTheme.typography.bodyLarge,
-                )
+		Text(
+			text = stringResource(R.string.compose_no_seasons),
+			style = MaterialTheme.typography.bodyLarge,
+		)
 	}
 }
 
@@ -200,12 +200,12 @@ private fun FocusedItemOverlay(
 		) {
 			item?.let { focusedItem ->
 				// Title
-                                Text(
-                                        text = focusedItem.name ?: stringResource(R.string.lbl_bracket_unknown),
-                                        style = MaterialTheme.typography.displayMedium.copy(
-                                                fontWeight = FontWeight.Bold,
-                                                fontSize = 42.sp,
-                                        ),
+				Text(
+					text = focusedItem.name ?: stringResource(R.string.lbl_bracket_unknown),
+					style = MaterialTheme.typography.displayMedium.copy(
+						fontWeight = FontWeight.Bold,
+						fontSize = 42.sp,
+					),
 					color = Color.White,
 					maxLines = 2,
 					overflow = TextOverflow.Ellipsis,
@@ -231,15 +231,15 @@ private fun FocusedItemOverlay(
 					focusedItem.runTimeTicks?.let { ticks ->
 						val minutes = (ticks / 10_000_000) / 60
 						if (minutes > 0) {
-                                                        Text(
-                                                                text = pluralStringResource(
-                                                                        R.plurals.minutes,
-                                                                        minutes,
-                                                                        minutes,
-                                                                ),
-                                                                style = MaterialTheme.typography.titleLarge,
-                                                                color = Color.White.copy(alpha = 0.7f),
-                                                        )
+							Text(
+								text = pluralStringResource(
+									R.plurals.minutes,
+									minutes,
+									minutes,
+								),
+								style = MaterialTheme.typography.titleLarge,
+								color = Color.White.copy(alpha = 0.7f),
+							)
 						}
 					}
 				}
@@ -469,12 +469,12 @@ private fun SeriesInformationOverlay(
 		) {
 			// Title
 			displayItem?.let { item ->
-                                Text(
-                                        text = item.name ?: stringResource(R.string.compose_unknown_title),
-                                        style = MaterialTheme.typography.displayMedium.copy(
-                                                fontWeight = FontWeight.Bold,
-                                                fontSize = 48.sp,
-                                        ),
+				Text(
+					text = item.name ?: stringResource(R.string.compose_unknown_title),
+					style = MaterialTheme.typography.displayMedium.copy(
+						fontWeight = FontWeight.Bold,
+						fontSize = 48.sp,
+					),
 					color = Color.White,
 					maxLines = 2,
 					overflow = TextOverflow.Ellipsis,
@@ -493,12 +493,14 @@ private fun SeriesInformationOverlay(
 						// Show series year range
 						val startYear = series.productionYear
 						val endYear = series.endDate?.year
-                                                val yearText = when {
-                                                        startYear != null && endYear != null && endYear != startYear -> "$startYear - $endYear"
-                                                        startYear != null && series.status?.lowercase() == "continuing" -> "$startYear - ${stringResource(R.string.lbl_present)}"
-                                                        startYear != null -> startYear.toString()
-                                                        else -> null
-                                                }
+						val yearText = when {
+							startYear != null && endYear != null && endYear != startYear -> "$startYear - $endYear"
+							startYear != null && series.status?.lowercase() == "continuing" -> "$startYear - ${stringResource(
+								R.string.lbl_present,
+							)}"
+							startYear != null -> startYear.toString()
+							else -> null
+						}
 						yearText?.let { year ->
 							Text(
 								text = year,
@@ -523,12 +525,12 @@ private fun SeriesInformationOverlay(
 							verticalAlignment = Alignment.CenterVertically,
 							horizontalArrangement = Arrangement.spacedBy(4.dp),
 						) {
-                                                        Icon(
-                                                                painter = painterResource(R.drawable.ic_star),
-                                                                contentDescription = stringResource(R.string.lbl_rating),
-                                                                tint = Color.Yellow,
-                                                                modifier = Modifier.size(20.dp),
-                                                        )
+							Icon(
+								painter = painterResource(R.drawable.ic_star),
+								contentDescription = stringResource(R.string.lbl_rating),
+								tint = Color.Yellow,
+								modifier = Modifier.size(20.dp),
+							)
 							Text(
 								text = String.format("%.1f", rating),
 								style = MaterialTheme.typography.titleLarge.copy(
@@ -568,15 +570,15 @@ private fun SeriesInformationOverlay(
 					if (focusedItem == null) {
 						series?.childCount?.let { count ->
 							if (count > 0) {
-                                                                Text(
-                                                                        text = pluralStringResource(
-                                                                                R.plurals.episodes,
-                                                                                count,
-                                                                                count,
-                                                                        ),
-                                                                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
-                                                                        color = Color.White.copy(alpha = 0.7f),
-                                                                )
+								Text(
+									text = pluralStringResource(
+										R.plurals.episodes,
+										count,
+										count,
+									),
+									style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
+									color = Color.White.copy(alpha = 0.7f),
+								)
 							}
 						}
 					}
@@ -586,15 +588,15 @@ private fun SeriesInformationOverlay(
 						item.runTimeTicks?.let { ticks ->
 							val minutes = (ticks / 10_000_000) / 60
 							if (minutes > 0) {
-                                                                Text(
-                                                                        text = pluralStringResource(
-                                                                                R.plurals.minutes,
-                                                                                minutes,
-                                                                                minutes,
-                                                                        ),
-                                                                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
-                                                                        color = Color.White.copy(alpha = 0.7f),
-                                                                )
+								Text(
+									text = pluralStringResource(
+										R.plurals.minutes,
+										minutes,
+										minutes,
+									),
+									style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
+									color = Color.White.copy(alpha = 0.7f),
+								)
 							}
 						}
 					}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="compose_error">Error: %1$s</string>
     <string name="compose_no_seasons">No seasons found</string>
     <string name="compose_unknown_title">Unknown Title</string>
-    <string name="lbl_present">Present</string>
     <string name="dot_separator">•</string>
     <string name="btn_cancel">Cancel</string>
     <string name="byletter_letters">ABCDEFGHIJKLMNOPQRSTUVWXYZ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,12 @@
     <string name="app_name_debug" translatable="false" tools:ignore="UnusedResources">Jellyfin Debug</string>
     <string name="video_error_unknown_error">Failed to load video</string>
     <string name="loading">Loading…</string>
+    <string name="compose_loading_seasons">Loading seasons…</string>
+    <string name="compose_error">Error: %1$s</string>
+    <string name="compose_no_seasons">No seasons found</string>
+    <string name="compose_unknown_title">Unknown Title</string>
+    <string name="lbl_present">Present</string>
+    <string name="dot_separator">•</string>
     <string name="btn_cancel">Cancel</string>
     <string name="byletter_letters">ABCDEFGHIJKLMNOPQRSTUVWXYZ</string>
     <string name="pref_playback">Playback</string>


### PR DESCRIPTION
## Summary
- add Compose messages to `strings.xml`
- use `stringResource`/`pluralStringResource` in ComposeSeasonScreen
- use the same resources in ComposeSeriesScreen
- extract bullet separator as string resource

## Testing
- `./gradlew testDebugUnitTest` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6854f79f5a308327bed024e84024a505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved localization support for season and series screens by replacing hardcoded UI text with translatable string resources.
  - Added localized pluralization for episode and minute counts.
  - Introduced new string resources for loading, error, empty states, unknown titles, and common UI elements to enhance internationalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->