### PR TITLE
Add JDK setup instructions

### DIFF
--- a/COMPOSE_MIGRATION_STATUS.md
+++ b/COMPOSE_MIGRATION_STATUS.md
@@ -3,6 +3,18 @@
 ## Overview
 This document tracks the progress of migrating the Jellyfin Android TV app from Leanback to Jetpack Compose for TV with Material 3 theming.
 
+## Development Setup
+
+The migration branch requires **Java 21**. If Java 21 is not available on your
+machine, update the version catalog to use JDK 17 instead:
+
+```toml
+# gradle/libs.versions.toml
+java-jdk = "17"
+```
+
+After modifying the catalog, ensure you run Gradle with JDK 17.
+
 ## ✅ Completed Components
 
 ### 1. Build Configuration

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Look through the following graphic to see if your native language could use some
 ### Dependencies
 
 - Android Studio
+- JDK 21 (or JDK 17 if `gradle/libs.versions.toml` is updated)
 
 ### Build
 


### PR DESCRIPTION
## Summary
- clarify Java setup in COMPOSE_MIGRATION_STATUS
- document required JDK in README

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6854fb0ba15083279e6dabd0f1bdd19b